### PR TITLE
ASVC-9781 set smartCopyConfigToHelmChart method into javaMicroserviceDeploymentPipeline

### DIFF
--- a/src/com/mikhalchuk/DeploymentPipelineHelper.groovy
+++ b/src/com/mikhalchuk/DeploymentPipelineHelper.groovy
@@ -52,7 +52,7 @@ class DeploymentPipelineHelper {
     def notifySlack(ctx) {
         pipeline.script {
             pipeline.wrap([$class: 'BuildUser']) {
-                pipeline.slackSend channel: "${ctx.slackChannel}", color: "good", message: "*${pipeline.BUILD_USER}* накатывает ветку *${ctx.currentBranchName}* на *${ctx.service} ${ctx.namespace}*.\n${ctx.dockerImage}\nСохраняйте спокойствие 😌"
+                pipeline.slackSend channel: "${ctx.slackChannel}", color: "good", message: "*${pipeline.BUILD_USER}* rolls branch *${ctx.currentBranchName}* on *${ctx.service} ${ctx.namespace}*.\n${ctx.dockerImage}\nKeep calm!"
             }
         }
     }

--- a/test/com/mikhalchuk/tests/callstacks/helmChartDeploymentPipelineTestSpec_super-service_dev_dev-dev.txt
+++ b/test/com/mikhalchuk/tests/callstacks/helmChartDeploymentPipelineTestSpec_super-service_dev_dev-dev.txt
@@ -71,9 +71,9 @@
                      helmChartDeploymentPipeline.sh({script=echo $(date +"%d-%m-%Y_%H-%M-%S"), returnStdout=true})
                      helmChartDeploymentPipeline.script(groovy.lang.Closure)
                         helmChartDeploymentPipeline.wrap({$class=BuildUser}, groovy.lang.Closure)
-                           helmChartDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* накатывает ветку *develop* на *super-service dev-dev*.
+                           helmChartDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* rolls branch *develop* on *super-service dev-dev*.
 super-service:latest
-Сохраняйте спокойствие 😌})
+Keep calm!})
             helmChartDeploymentPipeline.stage(checkout infra repo, groovy.lang.Closure)
                helmChartDeploymentPipeline.steps(groovy.lang.Closure)
                   helmChartDeploymentPipeline.script(groovy.lang.Closure)

--- a/test/com/mikhalchuk/tests/callstacks/helmChartDeploymentPipelineTestSpec_super-service_prod_prod.txt
+++ b/test/com/mikhalchuk/tests/callstacks/helmChartDeploymentPipelineTestSpec_super-service_prod_prod.txt
@@ -64,9 +64,9 @@
                      helmChartDeploymentPipeline.sh({script=echo $(date +"%d-%m-%Y_%H-%M-%S"), returnStdout=true})
                      helmChartDeploymentPipeline.script(groovy.lang.Closure)
                         helmChartDeploymentPipeline.wrap({$class=BuildUser}, groovy.lang.Closure)
-                           helmChartDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* накатывает ветку *master* на *super-service prod*.
+                           helmChartDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* rolls branch *master* on *super-service prod*.
 super-service:latest
-Сохраняйте спокойствие 😌})
+Keep calm!})
             helmChartDeploymentPipeline.stage(checkout infra repo, groovy.lang.Closure)
                helmChartDeploymentPipeline.steps(groovy.lang.Closure)
                   helmChartDeploymentPipeline.script(groovy.lang.Closure)

--- a/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_aservice_dev_dev-dev.txt
+++ b/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_aservice_dev_dev-dev.txt
@@ -72,9 +72,9 @@ javaOpts: "-Xms4g -Xmx4g -Dcom.sun.management.jmxremote -Dcom.sun.management.jmx
                      javaMicroserviceDeploymentPipeline.sh({script=echo $(date +"%d-%m-%Y_%H-%M-%S"), returnStdout=true})
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.wrap({$class=BuildUser}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* накатывает ветку *master* на *aservice dev-dev*.
+                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* rolls branch *master* on *aservice dev-dev*.
 aservice:latest
-Сохраняйте спокойствие 😌})
+Keep calm!})
             javaMicroserviceDeploymentPipeline.stage(checkout infra repo, groovy.lang.Closure)
                javaMicroserviceDeploymentPipeline.steps(groovy.lang.Closure)
                   javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)

--- a/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_aservice_dev_multi-domains.txt
+++ b/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_aservice_dev_multi-domains.txt
@@ -72,9 +72,9 @@ javaOpts: "-Xms4g -Xmx4g -Dcom.sun.management.jmxremote -Dcom.sun.management.jmx
                      javaMicroserviceDeploymentPipeline.sh({script=echo $(date +"%d-%m-%Y_%H-%M-%S"), returnStdout=true})
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.wrap({$class=BuildUser}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* накатывает ветку *develop* на *aservice multi-domains*.
+                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* rolls branch *develop* on *aservice multi-domains*.
 aservice:latest
-Сохраняйте спокойствие 😌})
+Keep calm!})
             javaMicroserviceDeploymentPipeline.stage(checkout infra repo, groovy.lang.Closure)
                javaMicroserviceDeploymentPipeline.steps(groovy.lang.Closure)
                   javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)

--- a/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_aservice_dev_no-javaOpts.txt
+++ b/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_aservice_dev_no-javaOpts.txt
@@ -72,9 +72,9 @@ javaOpts: null, description=Kubernetes POD resources requests and limits + JavaO
                      javaMicroserviceDeploymentPipeline.sh({script=echo $(date +"%d-%m-%Y_%H-%M-%S"), returnStdout=true})
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.wrap({$class=BuildUser}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* накатывает ветку *no-javaOpts* на *aservice no-javaOpts*.
+                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* rolls branch *no-javaOpts* on *aservice no-javaOpts*.
 aservice:latest
-Сохраняйте спокойствие 😌})
+Keep calm!})
             javaMicroserviceDeploymentPipeline.stage(checkout infra repo, groovy.lang.Closure)
                javaMicroserviceDeploymentPipeline.steps(groovy.lang.Closure)
                   javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)

--- a/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_aservice_prod_multi-domains.txt
+++ b/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_aservice_prod_multi-domains.txt
@@ -72,9 +72,9 @@ javaOpts: "-Xms4g -Xmx4g -Dcom.sun.management.jmxremote -Dcom.sun.management.jmx
                      javaMicroserviceDeploymentPipeline.sh({script=echo $(date +"%d-%m-%Y_%H-%M-%S"), returnStdout=true})
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.wrap({$class=BuildUser}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* накатывает ветку *master* на *aservice multi-domains*.
+                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* rolls branch *master* on *aservice multi-domains*.
 aservice:latest
-Сохраняйте спокойствие 😌})
+Keep calm!})
             javaMicroserviceDeploymentPipeline.stage(checkout infra repo, groovy.lang.Closure)
                javaMicroserviceDeploymentPipeline.steps(groovy.lang.Closure)
                   javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)

--- a/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_calculation_dev_dev-dev.txt
+++ b/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_calculation_dev_dev-dev.txt
@@ -72,9 +72,9 @@ javaOpts: "-Xmx2g -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.
                      javaMicroserviceDeploymentPipeline.sh({script=echo $(date +"%d-%m-%Y_%H-%M-%S"), returnStdout=true})
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.wrap({$class=BuildUser}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* накатывает ветку *develop* на *calculation dev-dev*.
+                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* rolls branch *develop* on *calculation dev-dev*.
 calculation:latest
-Сохраняйте спокойствие 😌})
+Keep calm!})
             javaMicroserviceDeploymentPipeline.stage(checkout infra repo, groovy.lang.Closure)
                javaMicroserviceDeploymentPipeline.steps(groovy.lang.Closure)
                   javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
@@ -86,7 +86,8 @@ calculation:latest
                   javaMicroserviceDeploymentPipeline.container(helm, groovy.lang.Closure)
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.catchError({buildResult=SUCCESS, stageResult=FAILURE}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.sh(cp src/main/resources/application.dev-dev.properties kubernetes/helm-chart/calculation/application.properties)
+                           javaMicroserviceDeploymentPipeline.sh(find . -name application.dev-dev.properties -type f -exec cp {} kubernetes/helm-chart/calculation/application.properties ";")
+                           javaMicroserviceDeploymentPipeline.sh(find . -name application.dev-dev.yaml -type f -exec cp {} kubernetes/helm-chart/calculation/application.yaml ";")
                            javaMicroserviceDeploymentPipeline.writeFile({file=kubernetes/helm-chart/calculation/values.yaml, text=replicaCount: 1
 gitBranch: "develop"
 image:

--- a/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_calculation_dev_prod.txt
+++ b/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_calculation_dev_prod.txt
@@ -72,9 +72,9 @@ javaOpts: "-Xmx2g -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.
                      javaMicroserviceDeploymentPipeline.sh({script=echo $(date +"%d-%m-%Y_%H-%M-%S"), returnStdout=true})
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.wrap({$class=BuildUser}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* накатывает ветку *master* на *calculation prod*.
+                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* rolls branch *master* on *calculation prod*.
 calculation:latest
-Сохраняйте спокойствие 😌})
+Keep calm!})
             javaMicroserviceDeploymentPipeline.stage(checkout infra repo, groovy.lang.Closure)
                javaMicroserviceDeploymentPipeline.steps(groovy.lang.Closure)
                   javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
@@ -86,7 +86,8 @@ calculation:latest
                   javaMicroserviceDeploymentPipeline.container(helm, groovy.lang.Closure)
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.catchError({buildResult=SUCCESS, stageResult=FAILURE}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.sh(cp src/main/resources/application.prod.properties kubernetes/helm-chart/calculation/application.properties)
+                           javaMicroserviceDeploymentPipeline.sh(find . -name application.prod.properties -type f -exec cp {} kubernetes/helm-chart/calculation/application.properties ";")
+                           javaMicroserviceDeploymentPipeline.sh(find . -name application.prod.yaml -type f -exec cp {} kubernetes/helm-chart/calculation/application.yaml ";")
                            javaMicroserviceDeploymentPipeline.writeFile({file=kubernetes/helm-chart/calculation/values.yaml, text=replicaCount: 1
 gitBranch: "master"
 image:

--- a/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_calculation_dev_tst-test.txt
+++ b/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_calculation_dev_tst-test.txt
@@ -72,9 +72,9 @@ javaOpts: "-Xmx2g -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.
                      javaMicroserviceDeploymentPipeline.sh({script=echo $(date +"%d-%m-%Y_%H-%M-%S"), returnStdout=true})
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.wrap({$class=BuildUser}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* накатывает ветку *develop* на *calculation tst-test*.
+                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* rolls branch *develop* on *calculation tst-test*.
 calculation:latest
-Сохраняйте спокойствие 😌})
+Keep calm!})
             javaMicroserviceDeploymentPipeline.stage(checkout infra repo, groovy.lang.Closure)
                javaMicroserviceDeploymentPipeline.steps(groovy.lang.Closure)
                   javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
@@ -86,7 +86,8 @@ calculation:latest
                   javaMicroserviceDeploymentPipeline.container(helm, groovy.lang.Closure)
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.catchError({buildResult=SUCCESS, stageResult=FAILURE}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.sh(cp src/main/resources/application.tst-test.properties kubernetes/helm-chart/calculation/application.properties)
+                           javaMicroserviceDeploymentPipeline.sh(find . -name application.tst-test.properties -type f -exec cp {} kubernetes/helm-chart/calculation/application.properties ";")
+                           javaMicroserviceDeploymentPipeline.sh(find . -name application.tst-test.yaml -type f -exec cp {} kubernetes/helm-chart/calculation/application.yaml ";")
                            javaMicroserviceDeploymentPipeline.writeFile({file=kubernetes/helm-chart/calculation/values.yaml, text=replicaCount: 1
 gitBranch: "develop"
 image:

--- a/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_calculation_prod_prod.txt
+++ b/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_calculation_prod_prod.txt
@@ -72,9 +72,9 @@ javaOpts: "-Xms1024m -Xmx1024m -Dcom.sun.management.jmxremote -Dcom.sun.manageme
                      javaMicroserviceDeploymentPipeline.sh({script=echo $(date +"%d-%m-%Y_%H-%M-%S"), returnStdout=true})
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.wrap({$class=BuildUser}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* накатывает ветку *master* на *calculation prod*.
+                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* rolls branch *master* on *calculation prod*.
 calculation:latest
-Сохраняйте спокойствие 😌})
+Keep calm!})
             javaMicroserviceDeploymentPipeline.stage(checkout infra repo, groovy.lang.Closure)
                javaMicroserviceDeploymentPipeline.steps(groovy.lang.Closure)
                   javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
@@ -86,7 +86,8 @@ calculation:latest
                   javaMicroserviceDeploymentPipeline.container(helm, groovy.lang.Closure)
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.catchError({buildResult=SUCCESS, stageResult=FAILURE}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.sh(cp src/main/resources/application.prod.properties kubernetes/helm-chart/calculation/application.properties)
+                           javaMicroserviceDeploymentPipeline.sh(find . -name application.prod.properties -type f -exec cp {} kubernetes/helm-chart/calculation/application.properties ";")
+                           javaMicroserviceDeploymentPipeline.sh(find . -name application.prod.yaml -type f -exec cp {} kubernetes/helm-chart/calculation/application.yaml ";")
                            javaMicroserviceDeploymentPipeline.writeFile({file=kubernetes/helm-chart/calculation/values.yaml, text=replicaCount: 1
 gitBranch: "master"
 image:

--- a/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_pricing_dev_dev-dev.txt
+++ b/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_pricing_dev_dev-dev.txt
@@ -72,9 +72,9 @@ javaOpts: "-Xms500m -Xmx4g -Dcom.sun.management.jmxremote -Dcom.sun.management.j
                      javaMicroserviceDeploymentPipeline.sh({script=echo $(date +"%d-%m-%Y_%H-%M-%S"), returnStdout=true})
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.wrap({$class=BuildUser}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* накатывает ветку *develop* на *pricing dev-dev*.
+                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* rolls branch *develop* on *pricing dev-dev*.
 pricing:latest
-Сохраняйте спокойствие 😌})
+Keep calm!})
             javaMicroserviceDeploymentPipeline.stage(checkout infra repo, groovy.lang.Closure)
                javaMicroserviceDeploymentPipeline.steps(groovy.lang.Closure)
                   javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
@@ -86,7 +86,8 @@ pricing:latest
                   javaMicroserviceDeploymentPipeline.container(helm, groovy.lang.Closure)
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.catchError({buildResult=SUCCESS, stageResult=FAILURE}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.sh(cp src/main/resources/application.dev-dev.properties kubernetes/helm-chart/pricing/application.properties)
+                           javaMicroserviceDeploymentPipeline.sh(find . -name application.dev-dev.properties -type f -exec cp {} kubernetes/helm-chart/pricing/application.properties ";")
+                           javaMicroserviceDeploymentPipeline.sh(find . -name application.dev-dev.yaml -type f -exec cp {} kubernetes/helm-chart/pricing/application.yaml ";")
                            javaMicroserviceDeploymentPipeline.writeFile({file=kubernetes/helm-chart/pricing/values.yaml, text=replicaCount: 1
 gitBranch: "develop"
 image:

--- a/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_pricing_dev_tst-test.txt
+++ b/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_pricing_dev_tst-test.txt
@@ -72,9 +72,9 @@ javaOpts: "-Xms500m -Xmx4g -Dcom.sun.management.jmxremote -Dcom.sun.management.j
                      javaMicroserviceDeploymentPipeline.sh({script=echo $(date +"%d-%m-%Y_%H-%M-%S"), returnStdout=true})
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.wrap({$class=BuildUser}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* накатывает ветку *develop* на *pricing tst-test*.
+                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* rolls branch *develop* on *pricing tst-test*.
 pricing:latest
-Сохраняйте спокойствие 😌})
+Keep calm!})
             javaMicroserviceDeploymentPipeline.stage(checkout infra repo, groovy.lang.Closure)
                javaMicroserviceDeploymentPipeline.steps(groovy.lang.Closure)
                   javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
@@ -86,7 +86,8 @@ pricing:latest
                   javaMicroserviceDeploymentPipeline.container(helm, groovy.lang.Closure)
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.catchError({buildResult=SUCCESS, stageResult=FAILURE}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.sh(cp src/main/resources/application.tst-test.properties kubernetes/helm-chart/pricing/application.properties)
+                           javaMicroserviceDeploymentPipeline.sh(find . -name application.tst-test.properties -type f -exec cp {} kubernetes/helm-chart/pricing/application.properties ";")
+                           javaMicroserviceDeploymentPipeline.sh(find . -name application.tst-test.yaml -type f -exec cp {} kubernetes/helm-chart/pricing/application.yaml ";")
                            javaMicroserviceDeploymentPipeline.writeFile({file=kubernetes/helm-chart/pricing/values.yaml, text=replicaCount: 1
 gitBranch: "develop"
 image:

--- a/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_pricing_prod_prod.txt
+++ b/test/com/mikhalchuk/tests/callstacks/javaMicroserviceDeploymentPipelineTestSpec_pricing_prod_prod.txt
@@ -72,9 +72,9 @@ javaOpts: "-Xms500m -Xmx4g -Dcom.sun.management.jmxremote -Dcom.sun.management.j
                      javaMicroserviceDeploymentPipeline.sh({script=echo $(date +"%d-%m-%Y_%H-%M-%S"), returnStdout=true})
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.wrap({$class=BuildUser}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* накатывает ветку *master* на *pricing prod*.
+                           javaMicroserviceDeploymentPipeline.slackSend({channel=java_services, color=good, message=*mikhalchuk* rolls branch *master* on *pricing prod*.
 pricing:latest
-Сохраняйте спокойствие 😌})
+Keep calm!})
             javaMicroserviceDeploymentPipeline.stage(checkout infra repo, groovy.lang.Closure)
                javaMicroserviceDeploymentPipeline.steps(groovy.lang.Closure)
                   javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
@@ -86,7 +86,8 @@ pricing:latest
                   javaMicroserviceDeploymentPipeline.container(helm, groovy.lang.Closure)
                      javaMicroserviceDeploymentPipeline.script(groovy.lang.Closure)
                         javaMicroserviceDeploymentPipeline.catchError({buildResult=SUCCESS, stageResult=FAILURE}, groovy.lang.Closure)
-                           javaMicroserviceDeploymentPipeline.sh(cp src/main/resources/application.prod.properties kubernetes/helm-chart/pricing/application.properties)
+                           javaMicroserviceDeploymentPipeline.sh(find . -name application.prod.properties -type f -exec cp {} kubernetes/helm-chart/pricing/application.properties ";")
+                           javaMicroserviceDeploymentPipeline.sh(find . -name application.prod.yaml -type f -exec cp {} kubernetes/helm-chart/pricing/application.yaml ";")
                            javaMicroserviceDeploymentPipeline.writeFile({file=kubernetes/helm-chart/pricing/values.yaml, text=replicaCount: 1
 gitBranch: "master"
 image:

--- a/vars/javaMicroserviceDeploymentPipeline.groovy
+++ b/vars/javaMicroserviceDeploymentPipeline.groovy
@@ -45,7 +45,7 @@ def call(body) {
                                 if (ctx.preDeploy) {
                                     helper.preDeploy(ctx)
                                 } else {
-                                    helper.copyConfigToHelmChart(ctx)
+                                    helper.smartCopyConfigToHelmChart(ctx)
                                 }
                                 helper.writeHelmValuesYaml(ctx)
                                 helper.generateK8SManifests(ctx)


### PR DESCRIPTION
Problem: After moving pricing service to server+client project structure the existing way of copying config files to helm chart during the Jenkins deployment pipeline is broken for pricing service.
Solution: User smart copy method to find config files in child directories.